### PR TITLE
Update StorePermissionRequest.php

### DIFF
--- a/src/App/Http/Requests/StorePermissionRequest.php
+++ b/src/App/Http/Requests/StorePermissionRequest.php
@@ -31,8 +31,8 @@ class StorePermissionRequest extends FormRequest
     public function rules()
     {
         return [
-            'name'          => 'required|max:60|unique:'.config('roles.permissionsTable').',name,'.$this->id.',id',
-            'slug'          => 'required|max:60|unique:'.config('roles.permissionsTable').',slug,'.$this->id.',id',
+            'name'          => 'required|max:60|unique:'.config('roles.permissionsTable').',name,'.$this->id,
+            'slug'          => 'required|max:60|unique:'.config('roles.permissionsTable').',slug,'.$this->id,
             'description'   => 'nullable|string|max:255',
             'model'         => 'required|string|max:60',
         ];


### PR DESCRIPTION
fix for postgresql "Invalid text representation: 7 ERROR: invalid input syntax for integer:...." error.